### PR TITLE
Crud Lists API - Get Leads by List, Add Leads to List

### DIFF
--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -5,6 +5,7 @@ require 'mrkt/concerns/connection'
 require 'mrkt/concerns/authentication'
 require 'mrkt/concerns/crud_leads'
 require 'mrkt/concerns/import_leads'
+require 'mrkt/concerns/crud_lists'
 
 module Mrkt
   class Client
@@ -12,6 +13,7 @@ module Mrkt
     include Authentication
     include CrudLeads
     include ImportLeads
+    include CrudLists
 
     attr_accessor :debug
 

--- a/lib/mrkt/concerns/crud_lists.rb
+++ b/lib/mrkt/concerns/crud_lists.rb
@@ -1,0 +1,22 @@
+module Mrkt
+  module CrudLists
+    def get_leads_by_list(list_id, fields: nil, batch_size: nil, next_page_token: nil)
+      params = {}
+      params[:fields] = fields if fields
+      params[:batchSize] = batch_size if batch_size
+      params[:nextPageToken] = next_page_token if next_page_token
+
+      get("/rest/v1/list/#{list_id}/leads.json", params)
+    end
+
+    def add_leads_to_list(list_id, lead_ids)
+      post("/rest/v1/lists/#{list_id}/leads.json") do |req|
+        params = {
+          input: lead_ids.map { |lead_id| { id: lead_id } }
+        }
+
+        json_payload(req, params)
+      end
+    end
+  end
+end

--- a/spec/concerns/crud_lists_spec.rb
+++ b/spec/concerns/crud_lists_spec.rb
@@ -1,0 +1,67 @@
+describe Mrkt::CrudLists do
+  include_context 'initialized client'
+
+  describe '#get_leads_by_list' do
+    let(:list_id) { '1001' }
+    let(:response_stub) do
+      {
+        requestId: 'ab12#12d6ab65024',
+        result: [
+          {
+            id: 1,
+            firstName: nil,
+            lastName: nil,
+            email: 'sample@example.com',
+            updatedAt: '2015-05-19 13:50:57',
+            createdAt: '2015-05-19 13:50:57'
+
+          }
+        ],
+        success: true
+      }
+    end
+
+    subject { client.get_leads_by_list(list_id) }
+
+    before do
+      stub_request(:get, "https://#{host}/rest/v1/list/#{list_id}/leads.json")
+        .with(query: {})
+        .to_return(json_stub(response_stub))
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
+
+  describe '#add_leads_to_list' do
+    let(:list_id) { '1001' }
+    let(:lead_ids) { ['1'] }
+    let(:request_body) do
+      {
+        input: [
+          { id: '1' }
+        ]
+      }
+    end
+    let(:response_stub) do
+      {
+        requestId: '16d3f#14d6da7449f',
+        result: [
+          {
+            id: 1,
+            status: 'added'
+          }
+        ],
+        success: true
+      }
+    end
+    subject { client.add_leads_to_list(list_id, lead_ids) }
+
+    before do
+      stub_request(:post, "https://#{host}/rest/v1/lists/#{list_id}/leads.json")
+        .with(json_stub(request_body))
+        .to_return(json_stub(response_stub))
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
+end


### PR DESCRIPTION
This PR adds support for two endpoints in the Marketo API. The [Get Leads by List](http://developers.marketo.com/documentation/rest/get-multiple-leads-by-list-id/) and [Add Leads to List](http://developers.marketo.com/documentation/rest/add-leads-to-list/) endpoints.