### PR TITLE
docs: fix client.get_leads arguments from string to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ client.debug = true
 ### Get leads matching an email, print their id and email
     
 ```ruby
-response = client.get_leads(:email, 'sammy@acme.com')
+response = client.get_leads(:email, ['sammy@acme.com'])
 response[:result].each do |result|
   p "id: #{result[:id]}, email: #{result[:email]}"
 end


### PR DESCRIPTION
```
[1] pry(main)> response = client.get_leads(:email, 'takuyan@example.com')
NoMethodError: undefined method `join' for "takuyan@example.com":String
from /Users/takuyan/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/mrkt-0.6.1/lib/mrkt/concerns/crud_leads.rb:6:in `get_leads'
```

```
[2] pry(main)> response = client.get_leads(:email, ['takuyan@example.com'])
=> {:requestId=>"17b86#153509999ad",
 :result=>
  [{:id=>9999372,
    :updatedAt=>"2016-03-07T06:24:12Z",
    :lastName=>nil,
    :email=>"takuyan@example.com",
    :createdAt=>"2016-02-02T09:17:04Z",
    :firstName=>nil}],
 :success=>true}
```