### PR TITLE
[WIP] each slice when over 300 leads on createupdate/delete

### DIFF
--- a/lib/mrkt/concerns/crud_leads.rb
+++ b/lib/mrkt/concerns/crud_leads.rb
@@ -17,7 +17,7 @@ module Mrkt
     def createupdate_leads(leads, action: 'createOrUpdate', lookup_field: nil, partition_name: nil, async_processing: nil)
       # see also: http://developers.marketo.com/documentation/rest/createupdate-leads/
       # > You can update a maximum of 300 leads with a single API call.
-      leads.each_slice(MAX_LEADS_SIZE) do |_leads|
+      leads.each_slice(MAX_LEADS_SIZE).map do |_leads|
         post('/rest/v1/leads.json') do |req|
           params = {
             action: action,
@@ -35,7 +35,7 @@ module Mrkt
     def delete_leads(leads)
       # see also: http://developers.marketo.com/documentation/rest/delete-lead/
       # > The max batch size for this endpoint is 300 leads.
-      leads.each_slice(MAX_LEADS_SIZE) do |_leads|
+      leads.each_slice(MAX_LEADS_SIZE).map do |_leads|
         delete('/rest/v1/leads.json') do |req|
           json_payload(req, input: map_lead_ids(_leads))
         end

--- a/lib/mrkt/concerns/crud_leads.rb
+++ b/lib/mrkt/concerns/crud_leads.rb
@@ -1,5 +1,7 @@
 module Mrkt
   module CrudLeads
+    MAX_LEADS_SIZE = 300
+
     def get_leads(filter_type, filter_values, fields: nil, batch_size: nil, next_page_token: nil)
       params = {
         filterType: filter_type,
@@ -13,22 +15,30 @@ module Mrkt
     end
 
     def createupdate_leads(leads, action: 'createOrUpdate', lookup_field: nil, partition_name: nil, async_processing: nil)
-      post('/rest/v1/leads.json') do |req|
-        params = {
-          action: action,
-          input: leads
-        }
-        params[:lookupField] = lookup_field if lookup_field
-        params[:partitionName] = partition_name if partition_name
-        params[:asyncProcessing] = async_processing if async_processing
+      # see also: http://developers.marketo.com/documentation/rest/createupdate-leads/
+      # > You can update a maximum of 300 leads with a single API call.
+      leads.each_slice(MAX_LEADS_SIZE) do |_leads|
+        post('/rest/v1/leads.json') do |req|
+          params = {
+            action: action,
+            input: _leads
+          }
+          params[:lookupField] = lookup_field if lookup_field
+          params[:partitionName] = partition_name if partition_name
+          params[:asyncProcessing] = async_processing if async_processing
 
-        json_payload(req, params)
+          json_payload(req, params)
+        end
       end
     end
 
     def delete_leads(leads)
-      delete('/rest/v1/leads.json') do |req|
-        json_payload(req, input: map_lead_ids(leads))
+      # see also: http://developers.marketo.com/documentation/rest/delete-lead/
+      # > The max batch size for this endpoint is 300 leads.
+      leads.each_slice(MAX_LEADS_SIZE) do |_leads|
+        delete('/rest/v1/leads.json') do |req|
+          json_payload(req, input: map_lead_ids(_leads))
+        end
       end
     end
 

--- a/spec/concerns/crud_leads_spec.rb
+++ b/spec/concerns/crud_leads_spec.rb
@@ -72,7 +72,7 @@ describe Mrkt::CrudLeads do
         .to_return(json_stub(response_stub))
     end
 
-    it { is_expected.to eq(response_stub) }
+    it { is_expected.to eq([response_stub]) }
   end
 
   describe '#delete_leads' do
@@ -101,7 +101,7 @@ describe Mrkt::CrudLeads do
         .to_return(json_stub(response_stub))
     end
 
-    it { is_expected.to eq(response_stub) }
+    it { is_expected.to eq([response_stub]) }
   end
 
   describe '#associate_lead' do


### PR DESCRIPTION
Fix for Over 300 leads
- http://developers.marketo.com/documentation/rest/createupdate-leads/
  
  > - [x] You can update a maximum of 300 leads with a single API call. 
  > - [ ] There is also a payload size 1 MB limit for this call.
- http://developers.marketo.com/documentation/rest/delete-lead/
  
  > - [x] Note: The max batch size for this endpoint is 300 leads.
- [x] fix exists specs
- [ ] add specs for limit of lead size and payload size
