### PR TITLE
Pass through logging options and retry_authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,16 @@ client = Mrkt::Client.new(
   client_secret: '7Gn0tuiHZiDHnzeu9P14uDQcSx9xIPPt')
 ```
 
-If you need verbosity during troubleshooting, set the client to debug mode
+If you need verbosity during troubleshooting, enable debug mode:
 
 ```ruby
-client.debug = true
+client = Mrkt::Client.new(
+  host: '123-abc-123.mktorest.com', 
+  client_id:  '4567e1cdf-0fae-4685-a914-5be45043f2d8', 
+  client_secret: '7Gn0tuiHZiDHnzeu9P14uDQcSx9xIPPt',
+  debug: true,
+  logger: ::Logger.new("log/marketo.log"), # optional, defaults to Faraday default of logging to STDOUT
+  log_options: {bodies: true}) # optional, defaults to Faraday default of only logging headers
 ```
 
 ### Retry authentication

--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ If you need verbosity during troubleshooting, set the client to debug mode
 client.debug = true
 ```
 
+### Retry authentication
+
+Since the Marketo API provides API access keys with a validity of 3600 seconds, if you are running an hourly cronjob it's possible that your subsequent call receives the same key from the previous hour, which is then immediately expired. If this is the case, you can configure the client to retry until receiving a valid key:
+
+```ruby
+client = Mrkt::Client.new(
+  host: '123-abc-123.mktorest.com',
+  client_id:  '4567e1cdf-0fae-4685-a914-5be45043f2d8',
+  client_secret: '7Gn0tuiHZiDHnzeu9P14uDQcSx9xIPPt'),
+  retry_authentication: true,
+  retry_authentication_count: 3, # default: 3
+  retry_authentication_wait_seconds: 1, # default: 0
+  )
+```
+
+This is turned off by default.
+
 ### Get leads matching an email, print their id and email
     
 ```ruby

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Since the Marketo API provides API access keys with a validity of 3600 seconds, 
 client = Mrkt::Client.new(
   host: '123-abc-123.mktorest.com',
   client_id:  '4567e1cdf-0fae-4685-a914-5be45043f2d8',
-  client_secret: '7Gn0tuiHZiDHnzeu9P14uDQcSx9xIPPt'),
+  client_secret: '7Gn0tuiHZiDHnzeu9P14uDQcSx9xIPPt',
   retry_authentication: true,
   retry_authentication_count: 3, # default: 3
   retry_authentication_wait_seconds: 1, # default: 0

--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -31,6 +31,10 @@ module Mrkt
       @client_id = options.fetch(:client_id)
       @client_secret = options.fetch(:client_secret)
 
+      @retry_authentication = options[:retry_authentication].nil? ? false : options[:retry_authentication]
+      @retry_authentication_count = options[:retry_authentication_count].nil? ? 3 : options[:retry_authentication_count].to_i
+      @retry_authentication_wait_seconds = options[:retry_authentication_wait_seconds].nil? ? 0 : options[:retry_authentication_wait_seconds].to_i
+
       @debug = options[:debug]
 
       @logger = options[:logger]

--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -31,6 +31,11 @@ module Mrkt
       @client_id = options.fetch(:client_id)
       @client_secret = options.fetch(:client_secret)
 
+      @debug = options[:debug]
+
+      @logger = options[:logger]
+      @log_options = options[:log_options]
+
       @options = options
     end
 

--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -31,9 +31,9 @@ module Mrkt
       @client_id = options.fetch(:client_id)
       @client_secret = options.fetch(:client_secret)
 
-      @retry_authentication = options[:retry_authentication].nil? ? false : options[:retry_authentication]
-      @retry_authentication_count = options[:retry_authentication_count].nil? ? 3 : options[:retry_authentication_count].to_i
-      @retry_authentication_wait_seconds = options[:retry_authentication_wait_seconds].nil? ? 0 : options[:retry_authentication_wait_seconds].to_i
+      @retry_authentication = options.fetch(:retry_authentication, false)
+      @retry_authentication_count = options.fetch(:retry_authentication_count, 3).to_i
+      @retry_authentication_wait_seconds = options.fetch(:retry_authentication_wait_seconds, 0).to_i
 
       @debug = options[:debug]
 

--- a/lib/mrkt/concerns/authentication.rb
+++ b/lib/mrkt/concerns/authentication.rb
@@ -1,7 +1,18 @@
 module Mrkt
   module Authentication
     def authenticate!
-      authenticate unless authenticated?
+      return if authenticated?
+
+      authenticate
+
+      if !authenticated? and @retry_authentication
+        @retry_authentication_count.times do
+          sleep(@retry_authentication_wait_seconds) if @retry_authentication_wait_seconds > 0
+          authenticate
+          break if authenticated?
+        end
+      end
+
       fail Mrkt::Errors::AuthorizationError, 'Client not authenticated' unless authenticated?
     end
 

--- a/lib/mrkt/concerns/connection.rb
+++ b/lib/mrkt/concerns/connection.rb
@@ -11,7 +11,10 @@ module Mrkt
         conn.request :multipart
         conn.request :url_encoded
 
-        conn.response :logger if @debug
+        if @debug
+          conn.response :logger, @logger, (@log_options || {})
+        end
+
         conn.response :mkto, content_type: /\bjson$/
 
         conn.options.timeout = @options[:read_timeout] if @options.key?(:read_timeout)

--- a/spec/concerns/authentication_spec.rb
+++ b/spec/concerns/authentication_spec.rb
@@ -22,6 +22,49 @@ describe Mrkt::Authentication do
     end
   end
 
+  describe '#authenticate!' do
+    it 'should authenticate and then be authenticated?' do
+      expect(client.authenticated?).to_not be true
+      client.authenticate!
+      expect(client.authenticated?).to be true
+    end
+
+    context 'when the token has expired and @retry_authentication = true' do
+      before { remove_request_stub(@authentication_request_stub) }
+
+      let(:expired_authentication_stub) do
+        { access_token: SecureRandom.uuid, token_type: 'bearer', expires_in: 0, scope: 'RestClient' }
+      end
+
+      let(:valid_authentication_stub) do
+        { access_token: SecureRandom.uuid, token_type: 'bearer', expires_in: 1234, scope: 'RestClient' }
+      end
+
+      subject(:client) { Mrkt::Client.new(host: host, client_id: client_id, client_secret: client_secret, retry_authentication: true) }
+
+      before do
+        stub_request(:get, "https://#{host}/identity/oauth/token")
+          .with(query: { client_id: client_id, client_secret: client_secret, grant_type: 'client_credentials' })
+          .to_return(json_stub(expired_authentication_stub)).times(3).then
+          .to_return(json_stub(valid_authentication_stub))
+      end
+
+      it 'should retry until getting valid token and then be authenticated?' do
+        expect(client.authenticated?).to_not be true
+        client.authenticate!
+        expect(client.authenticated?).to be true
+      end
+
+      it 'should stop retrying after @retry_authentication_count tries and then raise an error' do
+        client = Mrkt::Client.new(host: host, client_id: client_id, client_secret: client_secret, retry_authentication: true, retry_authentication_count: 2)
+
+        expect(client.authenticated?).to_not be true
+
+        expect { client.authenticate! }.to raise_error(Mrkt::Errors::Error, 'Client not authenticated')
+      end
+    end
+  end
+
   describe '#authenticated?' do
     subject { client.authenticated? }
 

--- a/spec/support/initialized_client.rb
+++ b/spec/support/initialized_client.rb
@@ -12,7 +12,7 @@ shared_context 'initialized client' do
   subject(:client) { Mrkt::Client.new(host: host, client_id: client_id, client_secret: client_secret) }
 
   before do
-    stub_request(:get, "https://#{host}/identity/oauth/token")
+    @authentication_request_stub = stub_request(:get, "https://#{host}/identity/oauth/token")
       .with(query: { client_id: client_id, client_secret: client_secret, grant_type: 'client_credentials' })
       .to_return(json_stub(authentication_stub))
   end


### PR DESCRIPTION
This allows you to pass in a custom logger, which is passed on to Faraday. It also allows you to specify ```@debug``` when initializing the client instead of having to set it after the client is created. The ```@log_options``` parameter is so you can specify e.g. ```{bodies: true}```; if left nil then Faraday will complain so the default passed on is an empty hash ```{}```