### PR TITLE
Add ability to bulk import custom objects

### DIFF
--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -9,6 +9,7 @@ require 'mrkt/concerns/crud_campaigns'
 require 'mrkt/concerns/crud_leads'
 require 'mrkt/concerns/crud_lists'
 require 'mrkt/concerns/import_leads'
+require 'mrkt/concerns/import_custom_objects'
 require 'mrkt/concerns/crud_custom_objects'
 require 'mrkt/concerns/crud_custom_activities'
 require 'mrkt/concerns/crud_programs'
@@ -23,6 +24,7 @@ module Mrkt
     include CrudLeads
     include CrudLists
     include ImportLeads
+    include ImportCustomObjects
     include CrudCustomObjects
     include CrudCustomActivities
     include CrudPrograms

--- a/lib/mrkt/concerns/import_custom_objects.rb
+++ b/lib/mrkt/concerns/import_custom_objects.rb
@@ -1,0 +1,24 @@
+module Mrkt
+  module ImportCustomObjects
+    def import_custom_object(file, custom_object, format = 'csv')
+      params = {
+        format: format,
+        file: Faraday::UploadIO.new(file, 'text/csv')
+      }
+
+      post("/bulk/v1/customobjects/#{custom_object}/import.json", params)
+    end
+
+    def import_custom_object_status(id, custom_object)
+      get("/bulk/v1/customobjects/#{custom_object}/import/#{id}/status.json")
+    end
+
+    def import_custom_object_failures(id, custom_object)
+      get("/bulk/v1/customobjects/#{custom_object}/import/#{id}/failures.json")
+    end
+
+    def import_custom_object_warnings(id, custom_object)
+      get("/bulk/v1/customobjects/#{custom_object}/import/#{id}/warnings.json")
+    end
+  end
+end

--- a/spec/concerns/import_custom_objects_spec.rb
+++ b/spec/concerns/import_custom_objects_spec.rb
@@ -1,0 +1,89 @@
+require 'tempfile'
+
+describe Mrkt::ImportCustomObjects do
+  include_context 'initialized client'
+  let(:custom_object) { 'car_c' }
+
+  describe '#import_custom_object' do
+    let(:file) { StringIO.new }
+    let(:response_stub) do
+      {
+        requestId: 'c015#15a68a23418',
+        success: true,
+        result: [
+          {
+            batchId: 1,
+            status: 'Importing',
+            objectApiName: custom_object
+          }
+        ]
+      }
+    end
+    subject { client.import_custom_object(file, custom_object) }
+
+    before do
+      stub_request(:post, "https://#{host}/bulk/v1/customobjects/#{custom_object}/import.json")
+        .with(headers: { content_type: %r{multipart/form-data; boundary=\S+} })
+        .to_return(json_stub(response_stub))
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
+
+  describe '#import_custom_object_status' do
+    let(:id) { 1 }
+    let(:response_stub) do
+      {
+        requestId: '2a5#15a68dd9be1',
+        result: [
+          {
+            batchId: id,
+            operation: 'import',
+            status: 'Complete',
+            objectApiName: 'car_c',
+            numOfObjectsProcessed: 3,
+            numOfRowsFailed: 0,
+            numOfRowsWithWarning: 0,
+            importTime: '2 second(s)',
+            message: 'Import succeeded, 3 records imported (3 members)'
+          }
+        ],
+        success: true
+      }
+    end
+    subject { client.import_custom_object_status(1, custom_object) }
+
+    before do
+      stub_request(:get, "https://#{host}/bulk/v1/customobjects/#{custom_object}/import/#{id}/status.json")
+        .to_return(json_stub(response_stub))
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
+
+  describe '#import_custom_object_failures' do
+    let(:id) { 1 }
+    let(:response_stub) { '' }
+    subject { client.import_custom_object_failures(1, custom_object) }
+
+    before do
+      stub_request(:get, "https://#{host}/bulk/v1/customobjects/#{custom_object}/import/#{id}/failures.json")
+        .to_return(headers: { content_length: 0 })
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
+
+  describe '#import_custom_object_warnings' do
+    let(:id) { 1 }
+    let(:response_stub) { '' }
+    subject { client.import_custom_object_warnings(1, custom_object) }
+
+    before do
+      stub_request(:get, "https://#{host}/bulk/v1/customobjects/#{custom_object}/import/#{id}/warnings.json")
+        .to_return(headers: { content_length: 0 })
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
+end


### PR DESCRIPTION
Adds bulk custom object import functionality. In addition to creating the job, you are able to poll the status and retrieve warnings/failures.

For reference: [custom object import documentation](http://developers.marketo.com/rest-api/bulk-import/bulk-custom-object-import/)

Question: Should be bump the version from `0.7.0` to `0.7.1`?
