### PR TITLE
"Get", update and approve an email and it's content

### DIFF
--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -13,6 +13,7 @@ require 'mrkt/concerns/import_custom_objects'
 require 'mrkt/concerns/crud_custom_objects'
 require 'mrkt/concerns/crud_custom_activities'
 require 'mrkt/concerns/crud_programs'
+require 'mrkt/concerns/crud_emails'
 
 module Mrkt
   class Client
@@ -28,6 +29,7 @@ module Mrkt
     include CrudCustomObjects
     include CrudCustomActivities
     include CrudPrograms
+    include CrudEmails
 
     attr_accessor :debug
 

--- a/lib/mrkt/concerns/crud_campaigns.rb
+++ b/lib/mrkt/concerns/crud_campaigns.rb
@@ -10,5 +10,18 @@ module Mrkt
         }
       end
     end
+
+    def schedule_campaign(id, run_at = nil)
+      if run_at.blank?
+        run_at = 2.minutes.from_now.in_time_zone(-8).iso8601
+      end
+      post_json("/rest/v1/campaigns/#{id}/schedule.json") do
+        {
+          input: {
+            runAt: run_at
+          }
+        }
+      end
+    end
   end
 end

--- a/lib/mrkt/concerns/crud_campaigns.rb
+++ b/lib/mrkt/concerns/crud_campaigns.rb
@@ -12,9 +12,6 @@ module Mrkt
     end
 
     def schedule_campaign(id, run_at = nil)
-      if run_at.blank?
-        run_at = 2.minutes.from_now.in_time_zone(-8).iso8601
-      end
       post_json("/rest/v1/campaigns/#{id}/schedule.json") do
         {
           input: {

--- a/lib/mrkt/concerns/crud_emails.rb
+++ b/lib/mrkt/concerns/crud_emails.rb
@@ -1,19 +1,12 @@
 module Mrkt
   module CrudEmails
-    # def get_email_by_id(id)
-    #   get("/rest/asset/v1/email/#{id}.json")
-    # end
+    def get_email_by_id(id)
+      get("/rest/asset/v1/email/#{id}.json")
+    end
 
-    # def get_email_by_name(name)
-    #   params = {
-    #     name: name
-    #   }
-    #   get("/rest/asset/v1/email/byName.json", params)
-    # end
-
-    # def get_email_content(id)
-    #   get("/rest/asset/v1/email/#{id}/content.json")
-    # end
+    def get_email_content(id)
+      get("/rest/asset/v1/email/#{id}/content.json")
+    end
 
     def approve_email_draft(id)
       post("/rest/asset/v1/email/#{id}/approveDraft.json")

--- a/lib/mrkt/concerns/crud_emails.rb
+++ b/lib/mrkt/concerns/crud_emails.rb
@@ -4,10 +4,6 @@ module Mrkt
       get("/rest/asset/v1/email/#{id}.json")
     end
 
-    def get_email_content(id)
-      get("/rest/asset/v1/email/#{id}/content.json")
-    end
-
     def approve_email_draft(id)
       post("/rest/asset/v1/email/#{id}/approveDraft.json")
     end
@@ -15,7 +11,6 @@ module Mrkt
     def update_email(id, subject)
       post("/rest/asset/v1/email/#{id}/content.json?subject={'type':'Text','value':'#{subject}'}")
     end
-
 
     def update_email_content(id, html_id, content, text_value = nil)
       post("/rest/asset/v1/email/#{id}/content/#{html_id}.json") do |req|

--- a/lib/mrkt/concerns/crud_emails.rb
+++ b/lib/mrkt/concerns/crud_emails.rb
@@ -19,10 +19,25 @@ module Mrkt
       post("/rest/asset/v1/email/#{id}/approveDraft.json")
     end
 
+    def update_email(id)
+      post("/rest/asset/v1/email/#{id}/content.json") do
+        { subject: {type: "string", value: "Announcement Alert"}}
+      end
+    end
+
     def update_email_content(id, html_id, content, text_value = nil)
       post("/rest/asset/v1/email/#{id}/content/#{html_id}.json") do |req|
         req.headers[:content_type] = 'multipart/form-data;charset=UTF-8'
         req.body = {type: "Text", value: content}
+      end
+    end
+
+    def update_email_full_content(id, content)
+      payload = {}
+      payload[:content] = Faraday::UploadIO.new(content.path, 'text/html')
+      # payload = {content: content}
+      post("/rest/asset/v1/email/#{id}/fullContent.json", payload) do |req|
+        req.headers[:content_type] = 'multipart/form-data;charset=UTF-8'
       end
     end
 

--- a/lib/mrkt/concerns/crud_emails.rb
+++ b/lib/mrkt/concerns/crud_emails.rb
@@ -1,43 +1,33 @@
 module Mrkt
   module CrudEmails
-    def get_email_by_id(id)
-      get("/rest/asset/v1/email/#{id}.json")
-    end
+    # def get_email_by_id(id)
+    #   get("/rest/asset/v1/email/#{id}.json")
+    # end
 
-    def get_email_by_name(name)
-      params = {
-        name: name
-      }
-      get("/rest/asset/v1/email/byName.json", params)
-    end
+    # def get_email_by_name(name)
+    #   params = {
+    #     name: name
+    #   }
+    #   get("/rest/asset/v1/email/byName.json", params)
+    # end
 
-    def get_email_content(id)
-      get("/rest/asset/v1/email/#{id}/content.json")
-    end
+    # def get_email_content(id)
+    #   get("/rest/asset/v1/email/#{id}/content.json")
+    # end
 
     def approve_email_draft(id)
       post("/rest/asset/v1/email/#{id}/approveDraft.json")
     end
 
-    def update_email(id)
-      post("/rest/asset/v1/email/#{id}/content.json") do
-        { subject: {type: "string", value: "Announcement Alert"}}
-      end
+    def update_email(id, subject)
+      post("/rest/asset/v1/email/#{id}/content.json?subject={'type':'Text','value':'#{subject}'}")
     end
+
 
     def update_email_content(id, html_id, content, text_value = nil)
       post("/rest/asset/v1/email/#{id}/content/#{html_id}.json") do |req|
         req.headers[:content_type] = 'multipart/form-data;charset=UTF-8'
         req.body = {type: "Text", value: content}
-      end
-    end
-
-    def update_email_full_content(id, content)
-      payload = {}
-      payload[:content] = Faraday::UploadIO.new(content.path, 'text/html')
-      # payload = {content: content}
-      post("/rest/asset/v1/email/#{id}/fullContent.json", payload) do |req|
-        req.headers[:content_type] = 'multipart/form-data;charset=UTF-8'
       end
     end
 

--- a/lib/mrkt/concerns/crud_emails.rb
+++ b/lib/mrkt/concerns/crud_emails.rb
@@ -8,13 +8,22 @@ module Mrkt
       params = {
         name: name
       }
-
       get("/rest/asset/v1/email/byName.json", params)
     end
 
     def get_email_content(id)
-
       get("/rest/asset/v1/email/#{id}/content.json")
+    end
+
+    def approve_email_draft(id)
+      post("/rest/asset/v1/email/#{id}/approveDraft.json")
+    end
+
+    def update_email_content(id, html_id, content, text_value = nil)
+      post("/rest/asset/v1/email/#{id}/content/#{html_id}.json") do |req|
+        req.headers[:content_type] = 'multipart/form-data;charset=UTF-8'
+        req.body = {type: "Text", value: content}
+      end
     end
 
   end

--- a/lib/mrkt/concerns/crud_emails.rb
+++ b/lib/mrkt/concerns/crud_emails.rb
@@ -1,0 +1,21 @@
+module Mrkt
+  module CrudEmails
+    def get_email_by_id(id)
+      get("/rest/asset/v1/email/#{id}.json")
+    end
+
+    def get_email_by_name(name)
+      params = {
+        name: name
+      }
+
+      get("/rest/asset/v1/email/byName.json", params)
+    end
+
+    def get_email_content(id)
+
+      get("/rest/asset/v1/email/#{id}/content.json")
+    end
+
+  end
+end

--- a/lib/mrkt/errors.rb
+++ b/lib/mrkt/errors.rb
@@ -47,6 +47,7 @@ class Mrkt::Errors
   end
 
   def self.find_by_response_code(response_code)
+    puts response_code.inspect
     const_get(RESPONSE_CODE_TO_ERROR.fetch(response_code, 'Error'))
   end
 end

--- a/lib/mrkt/errors.rb
+++ b/lib/mrkt/errors.rb
@@ -25,6 +25,7 @@ class Mrkt::Errors
     610  => 'RequestedResourceNotFound',
     611  => 'System',
     612  => 'InvalidContentType',
+    702  => 'NoDataFound',
     703  => 'DisabledFeature',
     1001 => 'TypeMismatch',
     1002 => 'MissingParamater',

--- a/lib/mrkt/errors.rb
+++ b/lib/mrkt/errors.rb
@@ -48,7 +48,6 @@ class Mrkt::Errors
   end
 
   def self.find_by_response_code(response_code)
-    puts response_code.inspect
     const_get(RESPONSE_CODE_TO_ERROR.fetch(response_code, 'Error'))
   end
 end

--- a/spec/concerns/crud_campaigns_spec.rb
+++ b/spec/concerns/crud_campaigns_spec.rb
@@ -13,6 +13,7 @@ describe Mrkt::CrudCampaigns do
          value: 'Value for other token'
        }]
     end
+
     subject { client.request_campaign(id, lead_ids, tokens) }
 
     before do
@@ -68,4 +69,45 @@ describe Mrkt::CrudCampaigns do
       end
     end
   end
+
+  describe '#schedule_campaign' do
+    let(:id) { 42 }
+
+    subject { client.schedule_campaign(id) }
+
+    before do
+      stub_request(:post, "https://#{host}/rest/v1/campaigns/#{id}/schedule.json")
+        .to_return(json_stub(response_stub))
+    end
+
+    context 'with an invalid campaign id' do
+      let(:response_stub) do
+        {
+          requestId: 'a2b#9a4567d34f',
+          success:   false,
+          errors:    [{
+                        code:    '1013',
+                        message: 'Campaign not found'
+                      }]
+        }
+      end
+
+      it 'should raise an Error' do
+        expect { subject }.to raise_error(Mrkt::Errors::ObjectNotFound)
+      end
+    end
+
+    context 'with valid campaign id' do
+      let(:response_stub) do
+        {
+          requestId: 'e42b#14272d07d78',
+          success:   true,
+          :result=>[{:id=>1254}]
+        }
+      end
+
+      it { is_expected.to eq(response_stub) }
+    end
+  end
+
 end

--- a/spec/concerns/crud_emails_spec.rb
+++ b/spec/concerns/crud_emails_spec.rb
@@ -1,6 +1,42 @@
 describe Mrkt::CrudCampaigns do
   include_context 'initialized client'
 
+  describe '#get_email_by_id' do
+    let(:id) { 42 }
+
+    subject { client.get_email_by_id(id) }
+
+    before do
+      stub_request(:get, "https://#{host}/rest/asset/v1/email/#{id}.json")
+        .to_return(json_stub(response_stub))
+    end
+
+    context 'with invalid email id' do
+      let(:response_stub) do
+        {
+          requestId: '7cdc#14eb6ae8a86',
+          success:   true,
+          warnings:  ["No assets found for the given search criteria."]
+        }
+      end
+
+      it { is_expected.to eq(response_stub) }
+    end
+
+    context 'for valid email id' do
+      let(:response_stub) do
+        {
+          requestId: 'e42b#14272d07d78',
+          success:   true
+        }
+      end
+
+      it { is_expected.to eq(response_stub) }
+    end
+  end
+
+
+
   describe '#approve_email_draft' do
     let(:id) { 42 }
 

--- a/spec/concerns/crud_emails_spec.rb
+++ b/spec/concerns/crud_emails_spec.rb
@@ -1,0 +1,85 @@
+describe Mrkt::CrudCampaigns do
+  include_context 'initialized client'
+
+  describe '#approve_email_draft' do
+    let(:id) { 42 }
+
+    subject { client.approve_email_draft(id) }
+
+    before do
+      stub_request(:post, "https://#{host}/rest/asset/v1/email/#{id}/approveDraft.json")
+        .to_return(json_stub(response_stub))
+    end
+
+    context 'with an invalid email id' do
+      let(:response_stub) do
+        {
+          requestId: 'a2b#9a4567d34f',
+          success:   false,
+          errors:    [{
+                        code:    '702',
+                        message: 'Email not found'
+                      }]
+        }
+      end
+
+      it 'should raise an Error' do
+        expect { subject }.to raise_error(Mrkt::Errors::NoDataFound)
+      end
+    end
+
+    context 'with valid email id' do
+      let(:response_stub) do
+        {
+          requestId: 'e42b#14272d07d78',
+          success:   true,
+          :result=>[{:id=>42}]
+        }
+      end
+
+      it { is_expected.to eq(response_stub) }
+    end
+  end
+
+  describe '#update_email' do
+    let(:id) { 42 }
+    let(:email_subject) { "Test" }
+
+    subject { client.update_email(id, email_subject) }
+
+    before do
+      stub_request(:post, "https://#{host}/rest/asset/v1/email/#{id}/content.json?subject={'type':'Text','value':'#{email_subject}'}")
+        .to_return(json_stub(response_stub))
+    end
+
+    context 'with an invalid email id' do
+      let(:response_stub) do
+        {
+          requestId: 'a2b#9a4567d34f',
+          success:   false,
+          errors:    [{
+                        code:    '702',
+                        message: 'Email not found'
+                      }]
+        }
+      end
+
+      it 'should raise an Error' do
+        expect { subject }.to raise_error(Mrkt::Errors::NoDataFound)
+      end
+    end
+
+    context 'with valid email id' do
+      let(:response_stub) do
+        {
+          requestId: 'e42b#14272d07d78',
+          success:   true,
+          :result=>[{:id=>42}]
+        }
+      end
+
+      it { is_expected.to eq(response_stub) }
+    end
+  end
+
+end


### PR DESCRIPTION
Hello, I was working with a team which needed to use the Marketo API
like an email marketing tool. The idea was to have a campaign which
would send an email whenever it was run. The content of the email being
sent could be changed whenever needed. As a result, I used the marketo
API for E-mails and campaigns and added some functionality to the mrkt
gem. These are the changes done:

1. Get an email's information using it's ID
2. Update an email's subject
3. Update the content of an email
4. Add code to schedule a campaign (doesn't work as expected, though)

The trouble is that currently scheduling a campaign using this code does
not run the campaign when needed, it' always 5 minutes after the request
is sent to Marketo (even though we're sending it in the format that Marketo
 needs it in.) Or perhaps I've made amistake. Please feel free to reject the
changes and let me know what I need to add/remove/change. I will really
appreciate your feedback on the pull request. Thanks!