### PR TITLE
Add middleware to handle unexpected non-json response for edge case

### DIFF
--- a/lib/mrkt/concerns/connection.rb
+++ b/lib/mrkt/concerns/connection.rb
@@ -13,6 +13,7 @@ module Mrkt
 
         conn.response :logger, @logger, (@log_options || {}) if @debug
         conn.response :mkto, content_type: /\bjson$/
+        conn.response :mkto_exceptional_response
 
         conn.options.timeout = @options[:read_timeout] if @options.key?(:read_timeout)
         conn.options.open_timeout = @options[:open_timeout] if @options.key?(:open_timeout)

--- a/lib/mrkt/faraday_middleware.rb
+++ b/lib/mrkt/faraday_middleware.rb
@@ -3,9 +3,11 @@ require 'faraday'
 module Mrkt
   module FaradayMiddleware
     autoload :Response, 'mrkt/faraday_middleware/response'
+    autoload :ExceptionalResponse, 'mrkt/faraday_middleware/exceptional_response'
   end
 
   if Faraday::Middleware.respond_to? :register_middleware
     Faraday::Response.register_middleware mkto: -> { Mrkt::FaradayMiddleware::Response }
+    Faraday::Response.register_middleware mkto_exceptional_response: -> { Mrkt::FaradayMiddleware::ExceptionalResponse }
   end
 end

--- a/lib/mrkt/faraday_middleware/exceptional_response.rb
+++ b/lib/mrkt/faraday_middleware/exceptional_response.rb
@@ -1,0 +1,25 @@
+module Mrkt
+  module FaradayMiddleware
+    # A middleware to handle exceptional non-json responses.
+    # In some cases, for example in trouble of marketo servers, we confirmed
+    # there is possibility that servers could respond with non json response
+    # unexpectedly.
+    class ExceptionalResponse < Faraday::Response::Middleware
+      ServerErrorStatuses = 500...600
+
+      def on_complete(env)
+        # Nothing to do by this handler if response content type is like json
+        return if env[:response_headers]['Content-Type'] =~ /\bjson$/
+
+        case env[:status]
+        when ServerErrorStatuses
+          raise Mrkt::Errors::Unknown, response_values(env)
+        end
+      end
+
+      def response_values(env)
+        {:status => env.status, :headers => env.response_headers, :body => env.body}
+      end
+    end
+  end
+end

--- a/lib/mrkt/faraday_middleware/exceptional_response.rb
+++ b/lib/mrkt/faraday_middleware/exceptional_response.rb
@@ -5,7 +5,7 @@ module Mrkt
     # there is possibility that servers could respond with non json response
     # unexpectedly.
     class ExceptionalResponse < Faraday::Response::Middleware
-      ServerErrorStatuses = 500...600
+      ServerErrorStatuses = 400...600
 
       def on_complete(env)
         # Nothing to do by this handler if response content type is like json

--- a/spec/concerns/authentication_spec.rb
+++ b/spec/concerns/authentication_spec.rb
@@ -8,6 +8,22 @@ describe Mrkt::Authentication do
       it { is_expected.to be_success }
     end
 
+    context 'on a unexpected non json response' do
+      before do
+        @authentication_request_stub = stub_request(:get, "https://#{host}/identity/oauth/token")
+          .with(query: { client_id: client_id, client_secret: client_secret, grant_type: 'client_credentials' })
+          .to_return(
+            status: 500,
+            headers: { content_type: 'text/plain' },
+            body: 'something wrong',
+          )
+      end
+
+      it 'should raise an Error' do
+        expect { subject }.to raise_error(Mrkt::Errors::Unknown)
+      end
+    end
+
     context 'when the token is invalid' do
       let(:authentication_stub) do
         {

--- a/spec/concerns/authentication_spec.rb
+++ b/spec/concerns/authentication_spec.rb
@@ -8,22 +8,6 @@ describe Mrkt::Authentication do
       it { is_expected.to be_success }
     end
 
-    context 'on a unexpected non json response' do
-      before do
-        @authentication_request_stub = stub_request(:get, "https://#{host}/identity/oauth/token")
-          .with(query: { client_id: client_id, client_secret: client_secret, grant_type: 'client_credentials' })
-          .to_return(
-            status: 500,
-            headers: { content_type: 'text/plain' },
-            body: 'something wrong',
-          )
-      end
-
-      it 'should raise an Error' do
-        expect { subject }.to raise_error(Mrkt::Errors::Unknown)
-      end
-    end
-
     context 'when the token is invalid' do
       let(:authentication_stub) do
         {

--- a/spec/faraday_middleware/exceptional_response_spec.rb
+++ b/spec/faraday_middleware/exceptional_response_spec.rb
@@ -1,0 +1,41 @@
+describe Mrkt::FaradayMiddleware::ExceptionalResponse do
+	before do
+    response = lambda { |env|
+      [status, {'Content-Type' => content_type}, body]
+    }
+    @conn = Faraday.new do |b|
+      b.use Mrkt::FaradayMiddleware::ExceptionalResponse
+      b.adapter :test do |stub|
+        stub.get('/', &response)
+      end
+    end
+  end
+
+  context 'with application/json and with server error' do
+    let(:content_type) { 'application/json' }
+    let(:status) { 500 }
+    let(:body) { '{}' }
+
+    it 'does nothing' do
+      expect(@conn.get('/').body).to eq body
+    end
+  end
+
+  context 'with non json content-type and with server error' do
+    let(:content_type) { 'text/plain' }
+    let(:status) { 500 }
+    let(:body) { 'something wrong' }
+
+    it { expect { @conn.get('/') }.to raise_error(Mrkt::Errors::Unknown) }
+  end
+
+  context 'with non json content-type but with successful response' do
+    let(:content_type) { 'text/html' }
+    let(:status) { 200 }
+    let(:body) { 'ok' }
+
+    it 'does nothing' do
+      expect(@conn.get('/').body).to eq body
+    end
+  end
+end


### PR DESCRIPTION
Hi, recently I got `NoMethodError` exception during Marketo side system trouble. This exception happened on `GET /identity/oauth/token` due to following backtrace.

```
got #<NoMethodError: undefined method `fetch' for String> with backtrace:
             # ./lib/mrkt/concerns/authentication.rb:34:in `block in authenticate'
             # ./lib/mrkt/concerns/authentication.rb:31:in `tap'
             # ./lib/mrkt/concerns/authentication.rb:31:in `authenticate'
```

This is a bug of mrkt gem of edge case handling. There is a case that Marketo's server could respond with non json content-type e.g. `text/plain`. Although I could not confirm what it's content type was accurately, I believe that the exception was caused by the content type,  from the stracktrace we got.  You can see the detail in the first commit to reproduce the bug.