### PR TITLE
chore: relax constraints on the faraday and faraday_middleware gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     mrkt (0.9.0)
-      faraday (> 0.9.0, < 0.14.0)
-      faraday_middleware (> 0.9.0, < 0.13.0)
+      faraday (> 0.9.0, < 1.0)
+      faraday_middleware (> 0.9.0, < 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,9 +19,9 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
-    faraday (0.13.1)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.12.2)
+    faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     hashdiff (0.3.7)
     json (2.1.0)

--- a/mrkt.gemspec
+++ b/mrkt.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_dependency 'faraday', '> 0.9.0', '< 0.14.0'
-  spec.add_dependency 'faraday_middleware', '> 0.9.0', '< 0.13.0'
+  spec.add_dependency 'faraday', '> 0.9.0', '< 1.0'
+  spec.add_dependency 'faraday_middleware', '> 0.9.0', '< 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
Hello,

It looks like Faraday's latest stable release is 0.15.4; this PR relaxes a couple of constraints to be compatible with it as well as future patches. I suspect the upcoming 1.0 release will require extensive testing so I've excluded it for now.