### PR TITLE
feat(lists): add remove_leads_from_list to crud_lists

### DIFF
--- a/lib/mrkt/concerns/crud_lists.rb
+++ b/lib/mrkt/concerns/crud_lists.rb
@@ -14,5 +14,11 @@ module Mrkt
         { input: map_lead_ids(lead_ids) }
       end
     end
+
+    def remove_leads_from_list(list_id, lead_ids)
+      delete("/rest/v1/lists/#{list_id}/leads.json") do |req|
+        json_payload(req, input: map_lead_ids(lead_ids))
+      end
+    end
   end
 end

--- a/spec/concerns/crud_lists_spec.rb
+++ b/spec/concerns/crud_lists_spec.rb
@@ -63,4 +63,37 @@ describe Mrkt::CrudLists do
 
     it { is_expected.to eq(response_stub) }
   end
+
+  describe '#remove_leads_from_list' do
+    let(:list_id) { '1001' }
+    let(:lead_ids) { ['1'] }
+    let(:request_body) do
+      {
+        input: [
+          { id: '1' }
+        ]
+      }
+    end
+    let(:response_stub) do
+      {
+        requestId: '10de4#1697e81c821',
+        result: [
+          {
+            id: 1,
+            status: 'removed'
+          }
+        ],
+        success: true
+      }
+    end
+    subject { client.remove_leads_from_list(list_id, lead_ids) }
+
+    before do
+      stub_request(:delete, "https://#{host}/rest/v1/lists/#{list_id}/leads.json")
+        .with(json_stub(request_body))
+        .to_return(json_stub(response_stub))
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
 end


### PR DESCRIPTION
Hi @raszi, 

Thanks for maintaining this gem. This is the first of a couple tiny PRs that I hope to open.

This simply implements `remove_leads_from_list` according to the [documentation](http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Static_Lists/removeLeadsFromListUsingDELETE)