### PR TITLE
Extend CRUD Leads

### DIFF
--- a/lib/mrkt/concerns/crud_asset_static_lists.rb
+++ b/lib/mrkt/concerns/crud_asset_static_lists.rb
@@ -17,7 +17,7 @@ module Mrkt
     end
 
     def get_static_list_by_name(name)
-      get("/rest/asset/v1/staticList/byName.json", {name: name})
+      get('/rest/asset/v1/staticList/byName.json', name: name)
     end
 
     def delete_static_list(id)

--- a/lib/mrkt/concerns/crud_leads.rb
+++ b/lib/mrkt/concerns/crud_leads.rb
@@ -1,5 +1,12 @@
 module Mrkt
   module CrudLeads
+    def get_lead_by_id(id, fields: nil)
+      params = {}
+      params[:fields] = fields.join(',') if fields
+
+      get("/rest/v1/lead/#{id}.json", params)
+    end
+
     def get_leads(filter_type, filter_values, fields: nil, batch_size: nil, next_page_token: nil)
       params = {
         filterType: filter_type,
@@ -45,6 +52,10 @@ module Mrkt
       params[:leadIds] = losing_lead_ids.join(',') if losing_lead_ids
 
       post_json("/rest/v1/leads/#{winning_lead_id}/merge.json?#{params.to_query}")
+    end
+
+    def describe_lead
+      get('/rest/v1/leads/describe.json')
     end
   end
 end

--- a/spec/concerns/crud_asset_static_lists_spec.rb
+++ b/spec/concerns/crud_asset_static_lists_spec.rb
@@ -20,9 +20,9 @@ describe Mrkt::CrudAssetStaticLists do
     subject { client.create_static_list(name, folder, description: description) }
 
     let(:name) { 'Test Static List Name' }
-    let(:folder) {
+    let(:folder) do
       { id: 14, type: 'Folder' }
-    }
+    end
     let(:description) { 'Provided description' }
     let(:response_stub) do
       {
@@ -146,7 +146,7 @@ describe Mrkt::CrudAssetStaticLists do
           success: true,
           errors: [],
           warnings: [
-            "No assets found for the given search criteria."
+            'No assets found for the given search criteria.'
           ]
         }
       end

--- a/spec/concerns/crud_leads_spec.rb
+++ b/spec/concerns/crud_leads_spec.rb
@@ -36,7 +36,7 @@ describe Mrkt::CrudLeads do
     end
 
     context 'when an array of fields is given' do
-      let(:fields) { ['email', 'dateOfBirth'] }
+      let(:fields) { %w[email dateOfBirth] }
       let(:response_stub) do
         {
           requestId: '33dd#169a6b5ba65',
@@ -283,7 +283,7 @@ describe Mrkt::CrudLeads do
               name: 'Email',
               readOnly: false
             }
-          },
+          }
         ],
         success: true
       }


### PR DESCRIPTION
Adds two more easy endpoints for Leads since there was time. I don't suspect, I won't get a chance to do anymore any time soon. Thanks!

This implements:
- [get_lead_by_id](http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Leads/getLeadByIdUsingGET)
- [describe_lead](http://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Leads/describeUsingGET_2)