### PR TITLE
Add optional partner_id param to auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Get the following from your Marketo admin:
 client = Mrkt::Client.new(
   host: '123-abc-123.mktorest.com',
   client_id:  '4567e1cdf-0fae-4685-a914-5be45043f2d8',
-  client_secret: '7Gn0tuiHZiDHnzeu9P14uDQcSx9xIPPt')
+  client_secret: '7Gn0tuiHZiDHnzeu9P14uDQcSx9xIPPt',
+  partner_id: '335b1c91511b8d8b49c7bbf66f53288f16f37b60_a0147938d3135f8ddb5a75850ea3c39313fd23c4' # optional 
+)
 ```
 
 If you need verbosity during troubleshooting, enable debug mode:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Get the following from your Marketo admin:
 * hostname, i.e. `'123-abc-123.mktorest.com'`
 * client id, e.g. `'4567e1cdf-0fae-4685-a914-5be45043f2d8'`
 * client secret, e.g. `'7Gn0tuiHZiDHnzeu9P14uDQcSx9xIPPt'`
+* partner id, e.g. `'335b1c91511b8d8b49c7bbf66f53288f16f37b60_a0147938d3135f8ddb5a75850ea3c39313fd23c4'` (optional)
 
 
 ## Usage

--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -40,6 +40,7 @@ module Mrkt
 
       @client_id = options.fetch(:client_id)
       @client_secret = options.fetch(:client_secret)
+      @partner_id = options[:partner_id]
 
       @retry_authentication = options.fetch(:retry_authentication, false)
       @retry_authentication_count = options.fetch(:retry_authentication_count, 3).to_i

--- a/lib/mrkt/concerns/authentication.rb
+++ b/lib/mrkt/concerns/authentication.rb
@@ -39,15 +39,27 @@ module Mrkt
     end
 
     def authentication_params
-      {
-        grant_type: 'client_credentials',
-        client_id: @client_id,
-        client_secret: @client_secret
-      }
+      merge_params(required_authentication_params, optional_authentication_params)
     end
 
     def add_authorization(req)
       req.headers[:authorization] = "Bearer #{@token}"
+    end
+
+    private
+
+    def optional_authentication_params
+      {
+          partner_id: @partner_id
+      }
+    end
+
+    def required_authentication_params
+      {
+          grant_type: 'client_credentials',
+          client_id: @client_id,
+          client_secret: @client_secret
+      }
     end
   end
 end

--- a/spec/concerns/authentication_spec.rb
+++ b/spec/concerns/authentication_spec.rb
@@ -29,6 +29,35 @@ describe Mrkt::Authentication do
       expect(client.authenticated?).to be true
     end
 
+    context 'with optional partner_id client option' do
+      before { remove_request_stub(@authentication_request_stub) }
+
+      let(:partner_id) { SecureRandom.uuid }
+
+      let(:client_options) do
+        {
+            host: host,
+            client_id: client_id,
+            client_secret: client_secret,
+            partner_id: partner_id
+        }
+      end
+
+      subject(:client) { Mrkt::Client.new(client_options) }
+
+      before do
+        stub_request(:get, "https://#{host}/identity/oauth/token")
+            .with(query: { client_id: client_id, client_secret: client_secret, partner_id: partner_id, grant_type: 'client_credentials' })
+            .to_return(json_stub(authentication_stub))
+      end
+
+      it 'should authenticate and then be authenticated?' do
+        expect(client.authenticated?).to_not be true
+        client.authenticate!
+        expect(client.authenticated?).to be true
+      end
+    end
+
     context 'when the token has expired and @retry_authentication = true' do
       before { remove_request_stub(@authentication_request_stub) }
 


### PR DESCRIPTION
Thanks for maintaining this repo, @raszi !

This PR adds the ability to specify an optional Marketo LaunchPoint `partner_id`, per [their documentation](https://developers.marketo.com/rest-api/endpoint-reference/authentication-endpoint-reference/#!/Identity/identityUsingGET) and [instructions](http://developers.marketo.com/support/Marketo_LaunchPoint_Technology_Partner_API_Key.pdf).

This requirement was not obvious to us during initial implementation - it may be fairly new. But it appears they're selectively enforcing inclusion of this ID in the auth call for tracking purposes now.