### PR TITLE
Fix default value for campaign tokens

### DIFF
--- a/lib/mrkt/concerns/crud_campaigns.rb
+++ b/lib/mrkt/concerns/crud_campaigns.rb
@@ -1,6 +1,6 @@
 module Mrkt
   module CrudCampaigns
-    def request_campaign(id, lead_ids, tokens = {})
+    def request_campaign(id, lead_ids, tokens = [])
       post_json("/rest/v1/campaigns/#{id}/trigger.json") do
         {
           input: {


### PR DESCRIPTION
The Readme suggests that `tokens` can be omitted, but when they are, the request fails.

Marketo expects an array for `tokens`. If an empty object is passed, Marketo rejects the request.