### PR TITLE
Bump faraday + faraday_middleware version range

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     mrkt (0.11.1)
-      faraday (> 0.9.0, < 1.0)
+      faraday (> 0.9.0, <= 0.17.3)
       faraday_middleware (> 0.9.0, <= 0.13.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    mrkt (0.11.0)
-      faraday (> 0.9.0, < 0.16.0)
-      faraday_middleware (> 0.9.0, < 0.16.0)
+    mrkt (0.11.1)
+      faraday (> 0.9.0, < 1.0)
+      faraday_middleware (> 0.9.0, <= 0.13.1)
 
 GEM
   remote: https://rubygems.org/
@@ -17,7 +17,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    faraday (0.15.4)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
@@ -27,7 +27,7 @@ GEM
     method_source (0.9.2)
     multipart-post (2.1.1)
     parallel (1.19.1)
-    parser (2.7.0.1)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -35,7 +35,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (4.0.2)
+    public_suffix (4.0.3)
     rainbow (3.0.0)
     rake (12.3.3)
     rspec (3.9.0)

--- a/lib/mrkt/version.rb
+++ b/lib/mrkt/version.rb
@@ -1,3 +1,3 @@
 module Mrkt
-  VERSION = '0.11.0'.freeze
+  VERSION = '0.11.1'.freeze
 end

--- a/mrkt.gemspec
+++ b/mrkt.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.3'
 
-  spec.add_dependency 'faraday', '> 0.9.0', '< 0.16.0'
-  spec.add_dependency 'faraday_middleware', '> 0.9.0', '< 0.16.0'
+  spec.add_dependency 'faraday', '> 0.9.0', '< 1.0'
+  spec.add_dependency 'faraday_middleware', '> 0.9.0', '<= 0.13.1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'pry-byebug', '~> 3.7'

--- a/mrkt.gemspec
+++ b/mrkt.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.3'
 
-  spec.add_dependency 'faraday', '> 0.9.0', '< 1.0'
+  spec.add_dependency 'faraday', '> 0.9.0', '<= 0.17.3'
   spec.add_dependency 'faraday_middleware', '> 0.9.0', '<= 0.13.1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
Faraday released version 1.0.0 on Jan 1 2020. I updated the faraday and faraday_middleware dependencies, and bumped the mrkt version from 0.11.0 to 0.11.1. I ran tests with `bundle exec rspec` and everything looks good. 

Closes #52 