### PR TITLE
Bump faraday and faraday_middleware to use version 1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     mrkt (0.11.1)
-      faraday (> 0.9.0, <= 0.17.3)
-      faraday_middleware (> 0.9.0, <= 0.13.1)
+      faraday (~> 1.0)
+      faraday_middleware (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -17,10 +17,10 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    faraday (0.17.3)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     hashdiff (1.0.0)
     jaro_winkler (1.5.4)
     json (2.3.0)

--- a/mrkt.gemspec
+++ b/mrkt.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.3'
 
-  spec.add_dependency 'faraday', '> 0.9.0', '<= 0.17.3'
-  spec.add_dependency 'faraday_middleware', '> 0.9.0', '<= 0.13.1'
+  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday_middleware', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'pry-byebug', '~> 3.7'


### PR DESCRIPTION
Hi!
faraday_middleware is now using faraday 1.0.
I bumped the version, ran all the tests and everything looks fine.

Let me know if I missed something or if there is some more work to do on the PR.

Thanks.