### PR TITLE
Support ruby 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 before_install:
   - gem update --system
   - bundle update --bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,3 @@ DEPENDENCIES
   rubocop (~> 0.87.1)
   simplecov (~> 0.17.1)
   webmock (~> 3.1)
-
-BUNDLED WITH
-   1.17.3

--- a/mrkt.gemspec
+++ b/mrkt.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w[lib]
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_dependency 'faraday', '~> 1.0'
   spec.add_dependency 'faraday_middleware', '~> 1.0'


### PR DESCRIPTION
- Fixed `required_ruby_version`. `~> 2.5` works only `2.x`
- Remove older bundler lock
- Testing 3.0.0