### PR TITLE
Add additional error field mappings.

### DIFF
--- a/lib/mrkt/errors.rb
+++ b/lib/mrkt/errors.rb
@@ -40,7 +40,26 @@ class Mrkt::Errors
     1011 => 'FieldNotSupported',
     1012 => 'InvalidCookieValue',
     1013 => 'ObjectNotFound',
-    1014 => 'FailedToCreateObject'
+    1014 => 'FailedToCreateObject',
+    1015 => 'LeadNotInList',
+    1016 => 'TooManyImports',
+    1017 => 'ObjectAlreadyExists',
+    1018 => 'CRMEnabled',
+    1019 => 'ImportInProgress',
+    1020 => 'TooManyCloneToProgram',
+    1021 => 'CompanyUpdateNotAllowed',
+    1022 => 'ObjectInUse',
+    1025 => 'ProgramStatusNotFound',
+    1026 => 'CustomObjectNotEnabled',
+    1027 => 'MaxActivityTypeLimitReached',
+    1028 => 'MaxFieldLimitReached',
+    1029 => 'BulkExportQuotaExceeded',
+    1035 => 'UnsupportedFilterType',
+    1036 => 'DuplicateObjectFoundInInput',
+    1042 => 'InvalidRunAtDate',
+    1048 => 'CustomObjectDiscardDraftFailed',
+    1049 => 'FailedToCreateActivity',
+    1077 => 'MergeLeadsCallFailedDueToFieldLength'
   }.freeze
 
   RESPONSE_CODE_TO_ERROR.each_value do |class_name|


### PR DESCRIPTION
The error codes library is a bit stale, and it felt like it could use an update with the [latest codes expressed in Marketo](https://developers.marketo.com/rest-api/error-codes/) - any that are > 1014. Please let me know if this feels like a sensible addition to this library. Thank you for your work on this!