### PR TITLE
feat: add program member create, update and list methods

### DIFF
--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -13,6 +13,7 @@ require 'mrkt/concerns/import_custom_objects'
 require 'mrkt/concerns/crud_custom_objects'
 require 'mrkt/concerns/crud_custom_activities'
 require 'mrkt/concerns/crud_programs'
+require 'mrkt/concerns/crud_program_members'
 require 'mrkt/concerns/crud_asset_static_lists'
 require 'mrkt/concerns/crud_asset_folders'
 
@@ -30,6 +31,7 @@ module Mrkt
     include CrudCustomObjects
     include CrudCustomActivities
     include CrudPrograms
+    include CrudProgramMembers
     include CrudAssetStaticLists
     include CrudAssetFolders
 

--- a/lib/mrkt/concerns/crud_program_members.rb
+++ b/lib/mrkt/concerns/crud_program_members.rb
@@ -3,5 +3,14 @@ module Mrkt
     def describe_program_members
       get('/rest/v1/programs/members/describe.json')
     end
+
+    def createupdate_program_members(program_id, lead_ids, status)
+      post_json("/rest/v1/programs/#{program_id}/members/status.json") do
+        params = {
+          statusName: status,
+          input: lead_ids.map { |lead_id| { leadId: lead_id } }
+        }
+      end
+    end
   end
 end

--- a/lib/mrkt/concerns/crud_program_members.rb
+++ b/lib/mrkt/concerns/crud_program_members.rb
@@ -1,0 +1,7 @@
+module Mrkt
+  module CrudProgramMembers
+    def describe_program_members
+      get('/rest/v1/programs/members/describe.json')
+    end
+  end
+end

--- a/lib/mrkt/concerns/crud_program_members.rb
+++ b/lib/mrkt/concerns/crud_program_members.rb
@@ -12,5 +12,20 @@ module Mrkt
         }
       end
     end
+
+    def get_program_members(program_id, filter_type, filter_values, fields: nil, batch_size: nil, next_page_token: nil)
+      params = {
+        filterType: filter_type,
+        filterValues: filter_values
+      }
+
+      optional = {
+        fields: fields,
+        batchSize: batch_size,
+        nextPageToken: next_page_token
+      }
+
+      get("/rest/v1/programs/#{program_id}/members.json", params, optional)
+    end
   end
 end

--- a/spec/concerns/crud_program_members_spec.rb
+++ b/spec/concerns/crud_program_members_spec.rb
@@ -95,4 +95,44 @@ describe Mrkt::CrudProgramMembers do
 
     it { is_expected.to eq(response_stub) }
   end
+
+  describe '#get_program_members' do
+    let(:filter_type) { 'leadId' }
+    let(:filter_values) { [1, 2] }
+    let(:program_id) { 1014 }
+    let(:response_stub) do
+      {
+        requestId: '4b6d#17d7c0530de',
+        result: [
+          {
+              seq: 0,
+              leadId: 1,
+              reachedSuccess: true,
+              programId: 1014,
+              acquiredBy: false,
+              membershipDate: '2021-12-02T16:22:12Z'
+          },
+          {
+              seq: 1,
+              leadId: 2,
+              reachedSuccess: true,
+              programId: 1014,
+              acquiredBy: false,
+              membershipDate: '2021-12-02T16:22:12Z'
+          }
+        ],
+        success: true,
+        moreResult: false
+    }
+    end
+    subject { client.get_program_members(program_id, filter_type, filter_values) }
+
+    before do
+      stub_request(:get, "https://#{host}/rest/v1/programs/#{program_id}/members.json")
+        .with(query: { filterType: filter_type, filterValues: filter_values.join(',') })
+        .to_return(json_stub(response_stub))
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
 end

--- a/spec/concerns/crud_program_members_spec.rb
+++ b/spec/concerns/crud_program_members_spec.rb
@@ -47,4 +47,52 @@ describe Mrkt::CrudProgramMembers do
 
     it { is_expected.to eq(response_stub) }
   end
+
+  describe '#createupdate_program_members' do
+    let(:program_id) { 123 }
+    let(:lead_ids) { [1, 2, 3] }
+    let(:status) { 'Registered' }
+    let(:request_body) do
+      {
+        statusName: 'Registered',
+        input: [
+          { leadId: 1 },
+          { leadId: 2 },
+          { leadId: 3 }
+        ]
+      }
+    end
+    let(:response_stub) do
+      {
+          requestId: 'c00c#17d7bf40f15',
+          result: [
+            {
+                seq: 0,
+                status: 'created',
+                leadId: 1
+            },
+            {
+                seq: 1,
+                status: 'created',
+                leadId: 2
+            },
+            {
+                seq: 2,
+                status: 'created',
+                leadId: 3
+            }
+          ],
+          success: true
+      }
+    end
+    subject { client.createupdate_program_members(program_id, lead_ids, status) }
+
+    before do
+      stub_request(:post, "https://#{host}/rest/v1/programs/#{program_id}/members/status.json")
+        .with(json_stub(request_body))
+        .to_return(json_stub(response_stub))
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
 end

--- a/spec/concerns/crud_program_members_spec.rb
+++ b/spec/concerns/crud_program_members_spec.rb
@@ -1,0 +1,50 @@
+describe Mrkt::CrudProgramMembers do
+  include_context 'initialized client'
+
+  describe '#describe_program_members' do
+    let(:response_stub) do
+      {
+        requestId: 'c245#14cd6830ae2',
+        result: [
+          {
+            name: 'API Program Membership',
+            description: 'Map for API program membership fields',
+            dedupeFields: %w[
+              leadId
+              programId
+            ],
+            searchableFields: [
+              ['leadId'],
+              ['livestormregistrationurl']
+            ],
+            fields: [
+              {
+                name: 'acquiredBy',
+                displayName: 'acquiredBy',
+                dataType: 'boolean',
+                updateable: false,
+                crmManaged: false
+              },
+              {
+                name: 'attendanceLikelihood',
+                displayName: 'attendanceLikelihood',
+                dataType: 'integer',
+                updateable: false,
+                crmManaged: false
+              }
+            ]
+          }
+        ],
+        success: true
+      }
+    end
+    subject { client.describe_program_members }
+
+    before do
+      stub_request(:get, "https://#{host}/rest/v1/programs/members/describe.json")
+        .to_return(json_stub(response_stub))
+    end
+
+    it { is_expected.to eq(response_stub) }
+  end
+end


### PR DESCRIPTION
This PR adds another marketo model `program members` to the supported cru(d) operations.

The implemented methods correspond to the following marketo rest api endpoints:
- [create_update_program_members](https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Program_Members/syncProgramMemberStatusUsingPOST)
- [get_program_members](https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Program_Members/getProgramMembersUsingGET)
- [describe_program_members](https://developers.marketo.com/rest-api/endpoint-reference/lead-database-endpoint-reference/#!/Program_Members/describeProgramMemberUsingGET2)

The implementation follows the same patterns used to implement the leads crud methods.