### PR TITLE
CI against Ruby v3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Ruby latest version is v3.1, but CI is not running.

## Changes
* Add ruby v3.1 to CI matrix.
* Chang ruby version to a string.
  * `3.0` is interpreted as `3`. CI runs on the latest version of v3.