### PR TITLE
Compatible Faraday v2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
+        gemfile: [faraday_1, faraday_2]
+
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   Exclude:
     - 'bin/**/*'
     - 'vendor/**/*'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     mrkt (1.2.1)
-      faraday (>= 1, < 3)
-      faraday_middleware (~> 1.0)
+      faraday (>= 1.10, < 3)
+      faraday-multipart
 
 GEM
   remote: https://rubygems.org/
@@ -40,8 +40,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     gem-release (2.2.2)
     hashdiff (1.0.1)
     method_source (1.0.0)

--- a/gemfiles/faraday_1.gemfile
+++ b/gemfiles/faraday_1.gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# require v1.10 or higher.
+# Because gem needs JSON middleware.
+#
+# see: https://github.com/lostisland/faraday/releases/tag/v1.10.0
+gem 'faraday', '~> 1.10'
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)

--- a/gemfiles/faraday_2.gemfile
+++ b/gemfiles/faraday_2.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'faraday', '~> 2'
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)

--- a/lib/mrkt/concerns/connection.rb
+++ b/lib/mrkt/concerns/connection.rb
@@ -12,7 +12,7 @@ module Mrkt
         conn.request :url_encoded
 
         conn.response :logger, @logger, (@log_options || {}) if @debug
-        conn.response :mkto, content_type: /\bjson$/
+        conn.response :mkto, content_type: /\bjson$/, parser_options: { symbolize_names: true }
 
         conn.options.timeout = @options[:read_timeout] if @options.key?(:read_timeout)
         conn.options.open_timeout = @options[:open_timeout] if @options.key?(:open_timeout)

--- a/lib/mrkt/faraday.rb
+++ b/lib/mrkt/faraday.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday/multipart'
 
 require 'mrkt/faraday/params_encoder'
 require 'mrkt/faraday_middleware'

--- a/lib/mrkt/faraday_middleware/response.rb
+++ b/lib/mrkt/faraday_middleware/response.rb
@@ -1,11 +1,9 @@
-require 'faraday_middleware'
+require 'faraday/response/json'
 
 module Mrkt
   module FaradayMiddleware
-    class Response < ::FaradayMiddleware::ParseJson
-      define_parser do |body|
-        JSON.parse(body, symbolize_names: true) unless body.strip.empty?
-      end
+    class Response < ::Faraday::Response::Json
+      private
 
       def process_response(env)
         super

--- a/mrkt.gemspec
+++ b/mrkt.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency 'faraday', '>= 1', '< 3'
-  spec.add_dependency 'faraday_middleware', '~> 1.0'
+  spec.add_dependency 'faraday', '>= 1.10', '< 3'
+  spec.add_dependency 'faraday-multipart'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'gem-release', '~> 2.1'


### PR DESCRIPTION
## Description
`faraday_middleware` is deprecated, and does not support Faraday v2.
From v1.10.0, faraday is bundled json middleware, and this gem can support Faraday v2.

## Changes
* Require Ruby: v2.6 or higer
  * Faraday v2 required Ruby v2.6.
  * ruby v2.5 is EOL in March 2021.
* Require Faraday v1.10 or higher
  * backport json middleware from this version.
  * ref. https://github.com/lostisland/faraday/pull/1400
* Require `faraday-multipart`
  * From Faraday v2, multipart middleware have been moved to separate faraday-multipart gem.
  * ref. https://github.com/lostisland/faraday/blob/v2.0.0/UPGRADING.md#bundled-middleware-moved-out
* Add CI matrix
  * Run tests on both versions of Faraday.