### PR TITLE
chore: drop Ruby 2.5 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Its life ended on 2021-04-05.

This also adds Ruby 3.2 support to the test suite.

https://www.ruby-lang.org/en/downloads/branches/